### PR TITLE
feat: add registration_certificate or intended_use_id to OID4VP Verifier request

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,8 +417,10 @@ Create a .env file in the root of your project and define the following variable
    SERVICE_URL=http://localhost:8084
    
    # OID4VP Configuration
-    VERIFIER-DOMAIN=verifier-backend.eudiw.dev
-    WALLET-SCHEME=eudi-openid4vp://
+   VERIFIER-DOMAIN=verifier-backend.eudiw.dev
+   WALLET-SCHEME=haip-vp://
+   INTENDED-USE-ID= # The identifier of configured Wallet Relying Party Intended Uses if one is made available by the verifier
+   REGISTRATION-CERTIFICATE-JWT= # a Wallet Relying Party Registration Certificate to be used
    ```
 
 Notes:
@@ -504,7 +506,9 @@ spring:
 
    This application requires users to authenticate and authorize the signature of documents with certificates they own through their EUDI Wallet.
    To enable this feature (authentication using PID), communication with a backend Verifier that supports OID4VP v1 is required.
-   It is mandatory to configure the domain and wallet scheme for OID4VP. TThis can be done in one of two ways:
+   It is mandatory to configure the domain and wallet scheme for OID4VP.You must also specify the registration certificate to use,
+   either by providing an `intended_use_id` (if the Verifier has a default test certificate configured) or a `registration_certificate_jwt`.
+   This can be done in one of two ways:
    
    1. By updating the **application.yml** located in the folder **authorization_server/src/main/resources**:
    ```
@@ -513,6 +517,8 @@ spring:
        domain: ${VERIFIER-DOMAIN}
        presentation-url: https://${VERIFIER-DOMAIN}/ui/presentations
        validation-url: https://${VERIFIER-DOMAIN}/utilities/validations/msoMdoc/deviceResponse
+       intended_use_id: ${INTENDED-USE-ID}
+       registration_certificate_Jwt: ${REGISTRATION-CERTIFICATE-JWT}
      wallet:
        scheme: ${WALLET-SCHEME}
    ```
@@ -520,6 +526,8 @@ spring:
    ```
    VERIFIER-DOMAIN=verifier-backend.eudiw.dev
    WALLET-SCHEME=eudi-openid4vp://
+   INTENDED-USE-ID=TEST-01
+   REGISTRATION-CERTIFICATE-JWT=
    ```
 
 3. **Update the application.yml**

--- a/authorization_server/src/main/java/eu/europa/ec/eudi/signer/r3/authorization_server/config/OID4VPConfig.java
+++ b/authorization_server/src/main/java/eu/europa/ec/eudi/signer/r3/authorization_server/config/OID4VPConfig.java
@@ -1,9 +1,13 @@
 package eu.europa.ec.eudi.signer.r3.authorization_server.config;
 
+import jakarta.validation.Valid;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties(prefix = "oid4vp")
+@Validated
 public class OID4VPConfig {
+	@Valid
 	private VerifierConfig verifier;
 	private WalletConfig wallet;
 

--- a/authorization_server/src/main/java/eu/europa/ec/eudi/signer/r3/authorization_server/config/VerifierConfig.java
+++ b/authorization_server/src/main/java/eu/europa/ec/eudi/signer/r3/authorization_server/config/VerifierConfig.java
@@ -16,10 +16,20 @@
 
 package eu.europa.ec.eudi.signer.r3.authorization_server.config;
 
+import jakarta.validation.constraints.AssertTrue;
+
 public class VerifierConfig {
     private String domain;
     private String presentationUrl;
     private String validationUrl;
+    private String intendedUseId;
+    private String registrationCertificateJwt;
+
+    @AssertTrue(message = "Either 'intendedUseId' or 'registrationCertificateId' must be defined")
+    private boolean isIntendedUseOrRegistrationCertificateValid() {
+        return (intendedUseId != null && !intendedUseId.isBlank())
+              || (registrationCertificateJwt != null && !registrationCertificateJwt.isBlank());
+    }
 
     public String getDomain() {
         return domain;
@@ -43,5 +53,21 @@ public class VerifierConfig {
 
     public void setValidationUrl(String validationUrl) {
         this.validationUrl = validationUrl;
+    }
+
+    public String getIntendedUseId() {
+        return intendedUseId;
+    }
+
+    public void setIntendedUseId(String intendedUseId) {
+        this.intendedUseId = intendedUseId;
+    }
+
+    public String getRegistrationCertificateJwt() {
+        return registrationCertificateJwt;
+    }
+
+    public void setRegistrationCertificateJwt(String registrationCertificateId) {
+        this.registrationCertificateJwt = registrationCertificateId;
     }
 }

--- a/authorization_server/src/main/java/eu/europa/ec/eudi/signer/r3/authorization_server/model/oid4vp/VerifierClient.java
+++ b/authorization_server/src/main/java/eu/europa/ec/eudi/signer/r3/authorization_server/model/oid4vp/VerifierClient.java
@@ -174,6 +174,8 @@ public class VerifierClient {
         if(isCrossDevice) bodyMessage = getCrossDeviceMessage(nonce);
         else bodyMessage = getSameDeviceMessage(userId, serviceUrl, nonce);
 
+        log.info(bodyMessage);
+
         // makes a request to the verifier
         HttpResponse response;
         try {
@@ -264,29 +266,30 @@ public class VerifierClient {
         return new JSONObject(dcqlQuery);
     }
 
-    private String getSameDeviceMessage(String userId, String serviceUrl, String nonce) {
+    private JSONObject getCommonStructureMessage(String nonce) {
         JSONObject dcqlQueryJSON = getDCQLQueryJSON();
 
-        String redirectUri = serviceUrl+"/oid4vp/callback?session_id="+userId+"&response_code={RESPONSE_CODE}";
-
-        // Set JSON Body
         JSONObject jsonBodyToInitPresentation = new JSONObject();
         jsonBodyToInitPresentation.put("type", "vp_token");
         jsonBodyToInitPresentation.put("nonce", nonce);
         jsonBodyToInitPresentation.put("dcql_query", dcqlQueryJSON);
+        String registrationCertificate = oid4VPConfig.getVerifier().getRegistrationCertificateJwt();
+        if(registrationCertificate != null && !registrationCertificate.isBlank())
+            jsonBodyToInitPresentation.put("registration_certificate", registrationCertificate);
+        else
+            jsonBodyToInitPresentation.put("intended_use_id", oid4VPConfig.getVerifier().getIntendedUseId());
+        return jsonBodyToInitPresentation;
+    }
+
+    private String getSameDeviceMessage(String userId, String serviceUrl, String nonce) {
+        JSONObject jsonBodyToInitPresentation = getCommonStructureMessage(nonce);
+        String redirectUri = serviceUrl+"/oid4vp/callback?session_id="+userId+"&response_code={RESPONSE_CODE}";
         jsonBodyToInitPresentation.put("wallet_response_redirect_uri_template", redirectUri);
         return jsonBodyToInitPresentation.toString();
     }
 
     private String getCrossDeviceMessage(String nonce) {
-        JSONObject dcqlQueryJSON = getDCQLQueryJSON();
-
-        // Set JSON Body
-        JSONObject jsonBodyToInitPresentation = new JSONObject();
-        jsonBodyToInitPresentation.put("type", "vp_token");
-        jsonBodyToInitPresentation.put("nonce", nonce);
-        jsonBodyToInitPresentation.put("dcql_query", dcqlQueryJSON);
-        return jsonBodyToInitPresentation.toString();
+        return getCommonStructureMessage(nonce).toString();
     }
 
     private String getLinkToWallet(String request_uri, String client_id) {

--- a/authorization_server/src/main/resources/application.yml
+++ b/authorization_server/src/main/resources/application.yml
@@ -22,6 +22,8 @@ oid4vp:
     domain: ${VERIFIER-DOMAIN}
     presentation-url: https://${VERIFIER-DOMAIN}/ui/presentations
     validation-url: https://${VERIFIER-DOMAIN}/utilities/validations/msoMdoc/deviceResponse
+    intended_use_id: ${INTENDED-USE-ID:}
+    registration_certificate_Jwt: ${REGISTRATION-CERTIFICATE-JWT:}
   wallet:
     scheme: ${WALLET-SCHEME}
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [0.5.0]
-_8 Apr 2026_
+_1 Aug 2026_
 
 ### Added
 - Additional logging and debug messages to aid troubleshooting.
@@ -15,6 +15,7 @@ _8 Apr 2026_
 - Updated Docker Java and Maven base images version.
 - Extracted OAuth2 constants into dedicated constants classes for improved maintainability.
 - Extracted OAuth2 flow logic into `OAuth2ValidationUtils`, centralizing reusable validation helpers. 
+- Updated OID4VP requests to specify either a registration certificate or intended use on Verifier requests.
 
 ### Fixed
 - Resolved issues flagged by SonarCloud, improving code quality.


### PR DESCRIPTION
Updated OID4VP requests to specify either a registration certificate or intended use on Verifier requests.